### PR TITLE
PieChart.pde function uses argument

### DIFF
--- a/content/examples/Basics/Form/PieChart/PieChart.pde
+++ b/content/examples/Basics/Form/PieChart/PieChart.pde
@@ -23,8 +23,8 @@ void pieChart(float diameter, int[] data) {
   for (int i = 0; i < data.length; i++) {
     float gray = map(i, 0, data.length, 0, 255);
     fill(gray);
-    arc(width/2, height/2, diameter, diameter, lastAngle, lastAngle+radians(angles[i]));
-    lastAngle += radians(angles[i]);
+    arc(width/2, height/2, diameter, diameter, lastAngle, lastAngle+radians(data[i]));
+    lastAngle += radians(data[i]);
   }
 }
 


### PR DESCRIPTION
pieChart function uses a mix of its argument (data[]) and the original global array (angles[]). Fixed so it uses only the argument.

see discussion:

https://forum.processing.org/two/discussion/17771/flaw-in-processing-org-website-piechart-example