### PR TITLE
Change array style to match other examples

### DIFF
--- a/content/api_en/loadStrings.xml
+++ b/content/api_en/loadStrings.xml
@@ -11,7 +11,7 @@
 <example>
 <image></image>
 <code><![CDATA[
-String lines[] = loadStrings("list.txt");
+String[] lines = loadStrings("list.txt");
 println("there are " + lines.length + " lines");
 for (int i = 0 ; i < lines.length; i++) {
   println(lines[i]);
@@ -22,7 +22,7 @@ for (int i = 0 ; i < lines.length; i++) {
 <example>
 <image></image>
 <code><![CDATA[
-String lines[] = loadStrings("http://processing.org/about/index.html");
+String[] lines = loadStrings("http://processing.org/about/index.html");
 println("there are " + lines.length + " lines");
 for (int i = 0 ; i < lines.length; i++) {
   println(lines[i]);


### PR DESCRIPTION
Processing documentation and code uses the style: `String[] arrayName=`.
This is the only Processing example I've seen that uses the compiler-equivalent `String arrayName[] =` declaration style. It is correct, but potentially confusing to new programmers -- especially because it the example doesn't obviously match the return type listed under Returns.

Changed to String[] style.